### PR TITLE
Fixed the AGP v8 Firebase Plugin Error (Bug)

### DIFF
--- a/android/app/build.gradle
+++ b/android/app/build.gradle
@@ -8,18 +8,28 @@ plugins {
     id "dev.flutter.flutter-gradle-plugin"
 }
 
+gradle.beforeProject { project ->
+    project.extensions.findByName('android')?.with {
+        buildFeatures.buildConfig = true
+    }
+}
+
 android {
     namespace = "com.example.lalamon"
     compileSdk = flutter.compileSdkVersion
     ndkVersion = flutter.ndkVersion
 
+    buildFeatures {
+        buildConfig = true
+    }
+
     compileOptions {
-        sourceCompatibility = JavaVersion.VERSION_1_8
-        targetCompatibility = JavaVersion.VERSION_1_8
+        sourceCompatibility JavaVersion.VERSION_17
+        targetCompatibility JavaVersion.VERSION_17
     }
 
     kotlinOptions {
-        jvmTarget = JavaVersion.VERSION_1_8
+        jvmTarget = '17'
     }
 
     defaultConfig {

--- a/android/build.gradle
+++ b/android/build.gradle
@@ -1,7 +1,29 @@
+buildscript {
+    ext {
+        buildFeatures = [
+            buildConfig: true
+        ]
+        agp_version = '8.2.1'
+    }
+    repositories {
+        google()
+        mavenCentral()
+    }
+    dependencies {
+        classpath "com.android.tools.build:gradle:$agp_version"
+        classpath 'com.google.gms:google-services:4.4.1'
+    }
+}
+
 allprojects {
     repositories {
         google()
         mavenCentral()
+    }
+    beforeEvaluate { project ->
+        project.pluginManager.withPlugin('com.android.library') {
+            project.android.buildFeatures.buildConfig = true
+        }
     }
 }
 

--- a/android/settings.gradle
+++ b/android/settings.gradle
@@ -18,7 +18,7 @@ pluginManagement {
 
 plugins {
     id "dev.flutter.flutter-plugin-loader" version "1.0.0"
-    id "com.android.application" version "8.1.0" apply false
+    id "com.android.application" version "8.2.1" apply false
     // START: FlutterFire Configuration
     id "com.google.gms.google-services" version "4.3.15" apply false
     // END: FlutterFire Configuration

--- a/lib/register_page.dart
+++ b/lib/register_page.dart
@@ -1,8 +1,6 @@
 import 'package:flutter/material.dart';
 import 'package:firebase_auth/firebase_auth.dart';
 import 'package:cloud_firestore/cloud_firestore.dart';
-import 'package:cached_network_image/cached_network_image.dart';
-import 'error_messages.dart';
 import 'home.dart';
 
 class RegisterScreen extends StatefulWidget {

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -34,9 +34,9 @@ dependencies:
   # The following adds the Cupertino Icons font to your application.
   # Use with the CupertinoIcons class for iOS style icons.
   cupertino_icons: ^1.0.8
-  firebase_core: 2.17.0
-  firebase_auth: 4.10.1
-  cloud_firestore: 4.9.3
+  firebase_core: ^2.15.1
+  firebase_auth: ^4.9.0
+  cloud_firestore: ^4.8.5
   http: ^1.1.0
   cached_network_image: ^3.3.0
 


### PR DESCRIPTION
## Fix AGP v8 Firebase Plugin Error

Changes Made:
- Updated AGP version to 8.2.1
- Set Java compatibility to version 17
- Enabled buildConfig for Android libraries
- Fixed Firebase plugin compatibility issues